### PR TITLE
Position restrict

### DIFF
--- a/Script/ControllerP1_joystick.cs
+++ b/Script/ControllerP1_joystick.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 using UnityEngine;
 using EZCameraShake;
 
+[System.Serializable]
+public class Boundary
+{
+    public float xMin, xMax, yMin, yMax, zMin, zMax;
+}
+
 public class ControllerP1_joystick : MonoBehaviour {
 
 
@@ -110,7 +116,12 @@ public class ControllerP1_joystick : MonoBehaviour {
 
     void FixedUpdate()
     {
-
+        rigid.position = new Vector3
+        (
+            Mathf.Clamp(rigid.position.x, boundary.xMin, boundary.xMax),
+            Mathf.Clamp(rigid.position.y, boundary.yMin, boundary.yMax),
+            Mathf.Clamp(rigid.position.z, boundary.zMin, boundary.zMax)
+        );
         Vector3 pos = rigid.position;
 
         float v_dir = Input.GetAxis("J2-V-Direct");

--- a/Script/ControllerP2.cs
+++ b/Script/ControllerP2.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 using UnityEngine;
 using EZCameraShake;
 
+[System.Serializable]
+public class Boundary
+{
+    public float xMin, xMax, yMin, yMax, zMin, zMax;
+}
+
 public class ControllerP2 : MonoBehaviour
 {
 
@@ -110,7 +116,12 @@ public class ControllerP2 : MonoBehaviour
 
     void FixedUpdate()
     {
-
+        rigid.position = new Vector3
+        (
+            Mathf.Clamp(rigid.position.x, boundary.xMin, boundary.xMax),
+            Mathf.Clamp(rigid.position.y, boundary.yMin, boundary.yMax),
+            Mathf.Clamp(rigid.position.z, boundary.zMin, boundary.zMax)
+        );
         Vector3 pos = rigid.position;
 
         float v_dir = Input.GetAxis("J-V-Direct");

--- a/Script/controllerP1.cs
+++ b/Script/controllerP1.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 using UnityEngine;
 using EZCameraShake;
 
+[System.Serializable]
+public class Boundary
+{
+    public float xMin, xMax, yMin, yMax, zMin, zMax;
+}
+
 public class controllerP1 : MonoBehaviour
 {
 
@@ -112,6 +118,12 @@ public class controllerP1 : MonoBehaviour
     {
 
         Vector3 mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+        rigid.position = new Vector3
+        (
+            Mathf.Clamp(rigid.position.x, boundary.xMin, boundary.xMax),
+            Mathf.Clamp(rigid.position.y, boundary.yMin, boundary.yMax),
+            Mathf.Clamp(rigid.position.z, boundary.zMin, boundary.zMax)
+        );
         Vector3 pos = rigid.position;
         Vector3 direction = mousePos - pos;
         angle = Mathf.Atan2(direction.x, direction.y) * Mathf.Rad2Deg;


### PR DESCRIPTION
Restricted position of players to prevent out of bounds errors.

Boundaries are assigned by public variables in the player controllers under new class Boundary. Fully customizable for any future levels.

Suggested x boundaries for P1 are xMin -8 and xMax -1
Suggested x boundaries for P2 are xMin 1 and xMax 8

Suggested y boundary is yMin -4, or if you can make it directly at the top of the floor that would be better

Make z boundary large enough to fit the players, but otherwise it's not that important since there is no movement in the z direction